### PR TITLE
fix: use the non-root node user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,6 @@ RUN yarn global add expo-cli@$EXPO_VERSION \
 
 COPY entrypoint.sh LICENSE.md README.md /
 
+USER node
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["--help"]


### PR DESCRIPTION
### Linked issue
This should fix #1.

### Additional context
Luckily, Node already provides a non-root user so let's use that one.
